### PR TITLE
Odesílání položky s jednotkovou cenou = 0.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -66,7 +66,7 @@ class Client {
                 if(!empty($cartItem->getName())) {
                     $item['productName'] = $cartItem->getName();
                 }
-                if(!empty($cartItem->getUnitPrice())) {
+                if($cartItem->getUnitPrice() !== null) {
                     $item['unitPrice'] = $cartItem->getUnitPrice();
                 }
                 if(!empty($cartItem->getQuantity())) {


### PR DESCRIPTION
Ahoj

podle oficiální dokumentace https://github.com/seznam/zbozi-konverze, je možné odesílat položku s jednotkovou cenou  = 0 (`unitPrice`).  

Upravil jsem podmínku v kódu, která při hodnotě 0, neodeslala jednotkovou cenu položky.