### PR TITLE
Odesílání položky s jednotkovou cenou = 0.

### DIFF
--- a/src/CartItem.php
+++ b/src/CartItem.php
@@ -8,7 +8,7 @@ class CartItem {
     protected $id, $name;
 
     /**
-     * @var float
+     * @var float|NULL
      */
     protected $unitPrice;
     /**
@@ -49,7 +49,7 @@ class CartItem {
     }
 
     /**
-     * @return float
+     * @return float|NULL
      */
     public function getUnitPrice() {
         return $this->unitPrice;

--- a/src/Client.php
+++ b/src/Client.php
@@ -66,7 +66,7 @@ class Client {
                 if(!empty($cartItem->getName())) {
                     $item['productName'] = $cartItem->getName();
                 }
-                if(!empty($cartItem->getUnitPrice())) {
+                if($cartItem->getUnitPrice() !== null) {
                     $item['unitPrice'] = $cartItem->getUnitPrice();
                 }
                 if(!empty($cartItem->getQuantity())) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -23,6 +23,10 @@ class ClientTest extends \PHPUnit_Framework_TestCase {
             ->addCartItem((new CartItem)
                 ->setId('ABC2')
                 ->setUnitPrice(2000)
+            )
+            ->addCartItem((new CartItem)
+                ->setId('ABC3')
+                ->setUnitPrice(0)
             );
         
         $request = $client->createRequest($order);
@@ -47,6 +51,11 @@ class ClientTest extends \PHPUnit_Framework_TestCase {
                 [
                     'itemId' => 'ABC2',
                     'unitPrice' => 2000,
+                    'quantity' => 1,
+                ],
+                [
+                    'itemId' => 'ABC3',
+                    'unitPrice' => 0,
                     'quantity' => 1,
                 ]
             ]


### PR DESCRIPTION
Ahoj

podle oficiální dokumentace https://github.com/seznam/zbozi-konverze, je možné odesílat položku s jednotkovou cenou = 0 (`unitPrice`).

Upravil jsem podmínku v kódu, která při hodnotě 0, neodeslala jednotkovou cenu položky. Dál jsem přidal úpravu statickou analýzu a upravil test pro položku s nulovou cenou.