### PR TITLE
Add PHP 7.4 and 8.0 to the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: php
 sudo: false
 php:
-  - 7.0
-  - 7.1
-  - 7.2
   - 7.3
+  - 7.4
+  - 8.0
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
   - composer install
 
 script:
-  - vendor/bin/phpunit --coverage-clover=coverage.xml
+  - vendor/bin/phpunit tests --coverage-clover=coverage.xml
   - vendor/bin/phpstan analyse --level=4 src
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 
 script:
   - vendor/bin/phpunit --coverage-clover=coverage.xml
-  - vendor/bin/phpstan analyse -c phpstan.neon --level=4 src
+  - vendor/bin/phpstan analyse --level=4 src
 
 after_script:
-  - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "5.6" ] ; then php ocular.phar code-coverage:upload --format=php-clover coverage.xml; fi;'
+  - bash -c 'php ocular.phar code-coverage:upload --format=php-clover coverage.xml'

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "psr/http-message": "~1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~5.0",
+    "phpunit/phpunit": "~9.5",
     "phpstan/phpstan": "~0.9|~0.10|~0.11"
   },
   "suggest": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,0 @@
-parameters:
-	ignoreErrors:
-		- '#Call to static method getSystemCaRootBundlePath\(\) on an unknown class Composer\\CaBundle\\CaBundle#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,18 +14,10 @@
          stopOnIncomplete="false"
          stopOnSkipped="false"
 
-         testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader"
          verbose="false">
     <testsuites>
         <testsuite name="Zbozicz">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <blacklist>
-            <directory>vendor</directory>
-        </blacklist>
-    </filter>
-
 </phpunit>

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -5,7 +5,7 @@ use Soukicz\Zbozicz\CartItem;
 use Soukicz\Zbozicz\Client;
 use Soukicz\Zbozicz\Order;
 
-class ClientTest extends \PHPUnit_Framework_TestCase {
+class ClientTest extends \PHPUnit\Framework\TestCase {
     function testOrderItems() {
         $client = new Client('1c342b11e6f1fc2c10242127ea2cacc8', '6caf7fe67a300047c72496969f637a9c', true);
         $order = new Order(1234);


### PR DESCRIPTION
Add PHP 7.4 and 8.0. Remove unsupported PHP versions. Upgrade PHPUnit for PHP 8.0 compatibility.

All tests are green: https://travis-ci.org/github/soukicz/zbozicz

<img width="1023" alt="Screenshot 2021-05-11 v 13 56 03" src="https://user-images.githubusercontent.com/374917/117811275-a5036600-b260-11eb-811b-5d61790ffcdb.png">
