### PR TITLE
PHP 8.1: guzzlehttp/psr7 v2.0 required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "php": ">=5.6.0",
     "ext-curl": "*",
     "ext-json": "*",
-    "guzzlehttp/psr7": "~1.3",
+    "guzzlehttp/psr7": "^1.3|^2.0",
     "psr/http-message": "~1.0"
   },
   "require-dev": {


### PR DESCRIPTION
 - fopen(): Passing null to parameter #3 ($use_include_path) of type bool is deprecated
 - fixed in https://github.com/guzzle/psr7/commit/f52e0898c1bee1125d8f0064b8d947c01ce11f11