### PR TITLE
Nulové ceny dopravy a dalších poplatků

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -44,7 +44,7 @@ class Client {
             $data['deliveryType'] = $order->getDeliveryType();
         }
 
-        if($order->getDeliveryPrice()) {
+        if($order->getDeliveryPrice() !== null) {
             $data['deliveryPrice'] = $order->getDeliveryPrice();
         }
 
@@ -52,7 +52,7 @@ class Client {
             $data['paymentType'] = $order->getPaymentType();
         }
 
-        if($order->getOtherCosts()) {
+        if($order->getOtherCosts() !== null) {
             $data['otherCosts'] = $order->getOtherCosts();
         }
 


### PR DESCRIPTION
Když je cena dopravy a dalších nákladů nastavena na 0, tak by se měla posílat, protože pak testovací rozhraní hlásí "nepřijato", což je matoucí. 